### PR TITLE
fix: corriger le bouton retour dans les DA (#7)

### DIFF
--- a/app/da/[id]/page.tsx
+++ b/app/da/[id]/page.tsx
@@ -342,32 +342,6 @@ export default function FormulaireDA() {
               aria-labelledby="sidemenu-title"
             >
               <div className="fr-sidemenu__inner">
-                <ul className="fr-btns-group fr-mt-2w">
-                  <li>
-                    <Link href="/" className="fr-btn fr-btn--sm">
-                      <span
-                        className="fr-icon-arrow-left-line"
-                        aria-hidden="true"
-                      ></span>
-                      Retour
-                    </Link>
-                  </li>
-                  {formId && (
-                    <li>
-                      <Link
-                        href={`/api/export-pdf/${formId}`}
-                        target="_blank"
-                        className="fr-btn fr-btn--sm fr-btn--tertiary"
-                      >
-                        <span
-                          className="fr-icon-download-line"
-                          aria-hidden="true"
-                        ></span>
-                        PDF
-                      </Link>
-                    </li>
-                  )}
-                </ul>
                 <button
                   aria-expanded="false"
                   aria-controls="sidemenu-collapse-1"
@@ -377,6 +351,32 @@ export default function FormulaireDA() {
                   Sommaire
                 </button>
                 <div className="fr-collapse" id="sidemenu-collapse-1">
+                  <ul className="fr-btns-group fr-mt-2w fr-mb-1w">
+                    <li>
+                      <Link href="/" className="fr-btn fr-btn--sm">
+                        <span
+                          className="fr-icon-arrow-left-line"
+                          aria-hidden="true"
+                        ></span>
+                        Retour
+                      </Link>
+                    </li>
+                    {formId && (
+                      <li>
+                        <Link
+                          href={`/api/export-pdf/${formId}`}
+                          target="_blank"
+                          className="fr-btn fr-btn--sm fr-btn--tertiary"
+                        >
+                          <span
+                            className="fr-icon-download-line"
+                            aria-hidden="true"
+                          ></span>
+                          PDF
+                        </Link>
+                      </li>
+                    )}
+                  </ul>
                   <div
                     style={{
                       display: "flex",

--- a/app/view/_components/ReadonlySidemenu.tsx
+++ b/app/view/_components/ReadonlySidemenu.tsx
@@ -72,44 +72,6 @@ export default function ReadonlySidemenu({
         aria-labelledby="sidemenu-title"
       >
         <div className="fr-sidemenu__inner">
-          <ul className="fr-btns-group fr-mt-2w">
-            <li>
-              <Link href="/" className="fr-btn fr-btn--sm">
-                <span
-                  className="fr-icon-arrow-left-line"
-                  aria-hidden="true"
-                ></span>
-                Retour
-              </Link>
-            </li>
-            {canEdit && (
-              <li>
-                <Link
-                  href={`/da/${id}`}
-                  className="fr-btn fr-btn--sm fr-btn--secondary"
-                >
-                  <span
-                    className="fr-icon-edit-line"
-                    aria-hidden="true"
-                  ></span>
-                  Éditer
-                </Link>
-              </li>
-            )}
-            <li>
-              <Link
-                href={pdfUrl || `/api/export-pdf/${id}`}
-                target="_blank"
-                className="fr-btn fr-btn--sm fr-btn--tertiary"
-              >
-                <span
-                  className="fr-icon-download-line"
-                  aria-hidden="true"
-                ></span>
-                PDF
-              </Link>
-            </li>
-          </ul>
           <button
             aria-expanded="false"
             aria-controls="sidemenu-collapse-view"
@@ -119,6 +81,44 @@ export default function ReadonlySidemenu({
             Sommaire
           </button>
           <div className="fr-collapse" id="sidemenu-collapse-view">
+            <ul className="fr-btns-group fr-mt-2w fr-mb-1w">
+              <li>
+                <Link href="/" className="fr-btn fr-btn--sm">
+                  <span
+                    className="fr-icon-arrow-left-line"
+                    aria-hidden="true"
+                  ></span>
+                  Retour
+                </Link>
+              </li>
+              {canEdit && (
+                <li>
+                  <Link
+                    href={`/da/${id}`}
+                    className="fr-btn fr-btn--sm fr-btn--secondary"
+                  >
+                    <span
+                      className="fr-icon-edit-line"
+                      aria-hidden="true"
+                    ></span>
+                    Éditer
+                  </Link>
+                </li>
+              )}
+              <li>
+                <Link
+                  href={pdfUrl || `/api/export-pdf/${id}`}
+                  target="_blank"
+                  className="fr-btn fr-btn--sm fr-btn--tertiary"
+                >
+                  <span
+                    className="fr-icon-download-line"
+                    aria-hidden="true"
+                  ></span>
+                  PDF
+                </Link>
+              </li>
+            </ul>
             <p
               className="fr-sidemenu__title fr-mb-1w"
               id="sidemenu-title"


### PR DESCRIPTION
Correction du bouton "Retour" dans les DA qui ne fonctionnait pas.

**Cause :** Les boutons d'action (Retour, PDF, Éditer) étaient placés dans `fr-sidemenu__inner` en dehors du `fr-collapse`, ce qui est non-standard pour le composant DSFR sidemenu et causait des interférences avec le JS DSFR.

**Correction :** Les boutons sont déplacés à l'intérieur du `fr-collapse`, conformément à la structure standard DSFR. Sur desktop, le CSS DSFR affiche toujours le `fr-collapse` dans les sidemenus.

Fixes #7
