### PR TITLE
ci(gitlab): CD sur PIC — chart Helm + build BuildKit mutualisé + gitops review

### DIFF
--- a/.github/workflows/gitlab-mirror.yml
+++ b/.github/workflows/gitlab-mirror.yml
@@ -1,0 +1,39 @@
+name: Mirror to GitLab PIC
+
+# Miroir GitHub -> GitLab PIC (déploiement immédiat de la CD côté GitLab).
+# pic.sg.social.gouv.fr est public : push direct depuis les runners GitHub (pas de proxy ici).
+# Secret requis : GITLAB_MIRROR_TOKEN (project access token write_repository sur tooling/da-manager).
+
+on:
+  push:
+    branches:
+      - main
+      - "feat/**"
+      - "fix/**"
+      - "chore/**"
+      - "migration/**"
+    tags:
+      - "v*"
+
+concurrency:
+  group: gitlab-mirror-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Push ref to GitLab PIC
+        env:
+          GL_TOKEN: ${{ secrets.GITLAB_MIRROR_TOKEN }}
+        run: |
+          set -e
+          REMOTE="https://oauth2:${GL_TOKEN}@pic.sg.social.gouv.fr/socialgouv/produits-dnum/tooling/da-manager.git"
+          if [ -n "${GITHUB_REF_NAME}" ] && [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            git push -f "$REMOTE" "refs/tags/${GITHUB_REF_NAME}"
+          else
+            git push -f "$REMOTE" "HEAD:refs/heads/${GITHUB_REF_NAME}"
+          fi

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,138 @@
+# ============================================================================
+# da-manager — CD sur GitLab PIC (repo mirroré depuis GitHub ; la CI de CODE
+# tests/lint/release reste sur GitHub). Ici : build image (BuildKit mutualisé)
+# -> publication chart OCI -> déploiement d'un env de REVIEW par branche
+# (à la vao : valeurs seedées à partir du slug de branche sanitizé).
+# Déploiement : Atlas v2 via ArgoCD synchronisant da-manager-gitops.
+# Voir docs/30-migrations/da-manager.md.
+#
+# Variables CI/CD à fournir (en plus des BUILDKIT_* du template) :
+#   GITOPS_TOKEN   token d'écriture sur da-manager-gitops (masqué)
+#   REVIEW_DOMAIN  domaine review de la zone Atlas (ex: review.<zone>.<atlas-domain>)
+# ============================================================================
+
+include:
+  - local: .gitlab/ci/buildkit.yml
+
+variables:
+  CHART_DIR: charts/da-manager
+  GITOPS_REPO: "socialgouv/produits-dnum/tooling/da-manager-gitops"
+  GITOPS_BRANCH: main
+  REVIEW_TEMPLATE: "templates/da-manager-review"
+  REVIEW_DOMAIN: "CHANGEME-review.atlas-domain"   # TODO: domaine review de la zone Atlas
+  # dev-login activé en review (build-arg NEXT_PUBLIC_* => build-time ; cf. docs).
+  NEXT_PUBLIC_ENABLE_DEV_LOGIN: "true"
+
+stages:
+  - build
+  - publish
+  - deploy
+
+workflow:
+  auto_cancel:
+    on_new_commit: interruptible
+  rules:
+    - if: $CI_COMMIT_BRANCH
+
+# Branches qui déclenchent un environnement de review
+.review-rules: &review-rules
+  - if: $CI_COMMIT_BRANCH =~ /^(feat|fix|chore|migration)\//
+  - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+
+build:
+  stage: build
+  extends: .buildkit-build
+  interruptible: true
+  variables:
+    BUILDKIT_IMAGE: "$CI_REGISTRY_IMAGE/app"
+    BUILDKIT_TAGS: "sha-$CI_COMMIT_SHA,$CI_COMMIT_REF_SLUG"
+    BUILDKIT_BUILD_ARGS: |
+      NEXT_PUBLIC_ENABLE_DEV_LOGIN=$NEXT_PUBLIC_ENABLE_DEV_LOGIN
+  rules: *review-rules
+
+# Publier le chart Helm en artefact OCI (snapshot SHA). appVersion = tag image immuable
+# -> le chart résout l'image automatiquement.
+publish-chart:
+  stage: publish
+  image:
+    name: alpine/helm:3.17
+    entrypoint: [""]
+  needs: ["build"]
+  rules: *review-rules
+  script:
+    - apk add --no-cache yq >/dev/null
+    - |
+      set -eu
+      VER="0.0.0-sha.${CI_COMMIT_SHORT_SHA}"
+      yq -i ".version = \"$VER\"" "$CHART_DIR/Chart.yaml"
+      yq -i ".appVersion = \"sha-${CI_COMMIT_SHA}\"" "$CHART_DIR/Chart.yaml"
+      helm registry login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" "$CI_REGISTRY"
+      helm package "$CHART_DIR" -d /tmp/pkg
+      helm push "/tmp/pkg/da-manager-${VER}.tgz" "oci://${CI_REGISTRY}/${CI_PROJECT_PATH}/charts"
+
+# Créer/mettre à jour l'app review dans le gitops (copie du template + seed du host).
+deploy-review:
+  stage: deploy
+  image:
+    name: alpine/helm:3.17
+    entrypoint: [""]
+  needs: ["publish-chart"]
+  variables:
+    GIT_STRATEGY: none
+  rules: *review-rules
+  environment:
+    name: review/$CI_COMMIT_REF_SLUG
+    url: https://da-manager-$CI_COMMIT_REF_SLUG.$REVIEW_DOMAIN
+    on_stop: stop-review
+    auto_stop_in: 1 week
+  script:
+    - apk add --no-cache git yq >/dev/null
+    - |
+      set -eu
+      VER="0.0.0-sha.${CI_COMMIT_SHORT_SHA}"
+      SLUG="$CI_COMMIT_REF_SLUG"
+      HOST="da-manager-${SLUG}.${REVIEW_DOMAIN}"
+      git config --global user.email "ci@da-manager.deploy"
+      git config --global user.name "da-manager CI"
+      git clone --depth 1 --branch "$GITOPS_BRANCH" \
+        "https://gitlab-ci-token:${GITOPS_TOKEN}@${CI_SERVER_HOST}/${GITOPS_REPO}.git" /tmp/gitops
+      cd /tmp/gitops
+      APP="apps/da-manager-review-${SLUG}"
+      rm -rf "$APP"
+      cp -r "$REVIEW_TEMPLATE" "$APP"
+      yq -i "(.dependencies[] | select(.name == \"da-manager\")).version = \"$VER\"" "$APP/Chart.yaml"
+      printf 'da-manager:\n  ingress:\n    host: "%s"\n' "$HOST" > "$APP/values.deploy.yaml"
+      git add -A
+      git diff --cached --quiet || git commit -m "deploy(review/${SLUG}): da-manager ${VER}"
+      git push origin "$GITOPS_BRANCH"
+
+# Détruire l'app review (manuel / auto_stop).
+stop-review:
+  stage: deploy
+  image: alpine:3.20
+  variables:
+    GIT_STRATEGY: none
+  rules:
+    - if: $CI_COMMIT_BRANCH =~ /^(feat|fix|chore|migration)\//
+      when: manual
+      allow_failure: true
+  environment:
+    name: review/$CI_COMMIT_REF_SLUG
+    action: stop
+  script:
+    - apk add --no-cache git >/dev/null
+    - |
+      set -eu
+      SLUG="$CI_COMMIT_REF_SLUG"
+      git config --global user.email "ci@da-manager.deploy"
+      git config --global user.name "da-manager CI"
+      git clone --depth 1 --branch "$GITOPS_BRANCH" \
+        "https://gitlab-ci-token:${GITOPS_TOKEN}@${CI_SERVER_HOST}/${GITOPS_REPO}.git" /tmp/gitops
+      cd /tmp/gitops
+      APP="apps/da-manager-review-${SLUG}"
+      if [ -d "$APP" ]; then
+        rm -rf "$APP"
+        git add -A
+        git commit -m "destroy(review/${SLUG})"
+        git push origin "$GITOPS_BRANCH"
+      fi

--- a/.gitlab/ci/buildkit.yml
+++ b/.gitlab/ci/buildkit.yml
@@ -41,6 +41,7 @@
         export no_proxy="127.0.0.1,localhost,${no_proxy:-}" NO_PROXY="127.0.0.1,localhost,${NO_PROXY:-}"
       fi
       apk add --no-cache curl >/dev/null
+      [ -n "${BUILDKIT_HTTP_PROXY:-}" ] && apk add --no-cache socat >/dev/null
 
       # 1. buildctl (client buildkit)
       curl -fsSL "https://github.com/moby/buildkit/releases/download/${BUILDCTL_VERSION}/buildkit-${BUILDCTL_VERSION}.linux-amd64.tar.gz" \
@@ -68,6 +69,19 @@
       fi
       echo "buildkitd: $ADDR"
 
+      # 4b. Tunnel TCP via proxy HTTP CONNECT (buildctl ne gère pas le proxy nativement).
+      #     Le SAN du cert daemon couvre *.buildkit.atlas.fabrique... -> --tlsservername OK.
+      TLS_SRV=""
+      if [ -n "${BUILDKIT_HTTP_PROXY:-}" ]; then
+        BK="${ADDR#tcp://}"; BKHOST="${BK%%:*}"; BKPORT="${BK##*:}"
+        PHOST="${BUILDKIT_HTTP_PROXY%%:*}"; PPORT="${BUILDKIT_HTTP_PROXY##*:}"
+        socat TCP-LISTEN:18080,fork,reuseaddr "PROXY:${PHOST}:${BKHOST}:${BKPORT},proxyport=${PPORT}" &
+        sleep 2
+        TLS_SRV="--tlsservername ${BKHOST}"
+        ADDR="tcp://127.0.0.1:18080"
+        echo "tunnel via ${PHOST}:${PPORT} -> ${BKHOST}:${BKPORT} (servername ${BKHOST})"
+      fi
+
       # 5. build-args (multi-lignes "K=V") -> "--opt build-arg:K=V ..."
       OPT_ARGS="$(printf '%s\n' "$BUILDKIT_BUILD_ARGS" | awk 'NF{printf " --opt build-arg:%s", $0}')"
 
@@ -79,7 +93,7 @@
 
       # 6. build + push (cache registre import/export)
       # shellcheck disable=SC2086
-      buildctl --addr "$ADDR" \
+      buildctl --addr "$ADDR" $TLS_SRV \
         --tlscacert "$CERT_DIR/ca.pem" --tlscert "$CERT_DIR/cert.pem" --tlskey "$CERT_DIR/key.pem" \
         build \
         --frontend dockerfile.v0 \

--- a/.gitlab/ci/buildkit.yml
+++ b/.gitlab/ci/buildkit.yml
@@ -7,9 +7,15 @@
 # cache registre. Voir docs/15-build-ci/buildkit-mutualise.md.
 #
 # Variables CI/CD requises (groupe/projet GitLab PIC) :
-#   BUILDKIT_DAEMON_ADDRESS  ex: tcp://buildkit.<...>:1234
-#   BUILDKIT_SVC_COUNT       nombre de réplicas (distribution modulo)
-#   BUILDKIT_CERT_CA / BUILDKIT_CERT / BUILDKIT_CERT_KEY  (mTLS inline, masqués/protégés)
+#   BUILDKIT_DAEMON_ADDRESS  ex: tcp://buildkit.atlas.fabrique.social.gouv.fr:1234
+#   BUILDKIT_SVC_COUNT       nombre de réplicas (distribution modulo, ex: 6)
+#   BUILDKIT_CERT_CA / BUILDKIT_CERT / BUILDKIT_CERT_KEY  (mTLS inline)
+# Optionnel (runners PIC derrière proxy intranet) :
+#   BUILDKIT_HTTP_PROXY      ex: proxyweb.intranet.social.gouv.fr:8002
+#     -> utilisé pour les TÉLÉCHARGEMENTS (buildctl/github, apk).
+#     NB: la connexion buildctl -> buildkitd (TCP/mTLS) suppose un egress DIRECT vers
+#     le LB public buildkit. Si l'egress est proxy-only, un tunnel TCP sera nécessaire
+#     (attention au SAN du cert : --addr doit matcher le SAN ou prévoir tlsservername).
 # Registre : variables natives $CI_REGISTRY*.
 # ============================================================================
 
@@ -28,6 +34,12 @@
   script:
     - |
       set -eu
+      # Proxy intranet (optionnel) : pour les téléchargements (github/buildctl, apk).
+      if [ -n "${BUILDKIT_HTTP_PROXY:-}" ]; then
+        export http_proxy="http://${BUILDKIT_HTTP_PROXY}" https_proxy="http://${BUILDKIT_HTTP_PROXY}"
+        export HTTP_PROXY="$http_proxy" HTTPS_PROXY="$https_proxy"
+        export no_proxy="127.0.0.1,localhost,${no_proxy:-}" NO_PROXY="127.0.0.1,localhost,${NO_PROXY:-}"
+      fi
       apk add --no-cache curl >/dev/null
 
       # 1. buildctl (client buildkit)

--- a/.gitlab/ci/buildkit.yml
+++ b/.gitlab/ci/buildkit.yml
@@ -38,10 +38,12 @@
       if [ -n "${BUILDKIT_HTTP_PROXY:-}" ]; then
         export http_proxy="http://${BUILDKIT_HTTP_PROXY}" https_proxy="http://${BUILDKIT_HTTP_PROXY}"
         export HTTP_PROXY="$http_proxy" HTTPS_PROXY="$https_proxy"
-        export no_proxy="127.0.0.1,localhost,${no_proxy:-}" NO_PROXY="127.0.0.1,localhost,${NO_PROXY:-}"
+        # buildctl (TCP/gRPC) vers buildkit en DIRECT : on exclut l'hôte buildkit + l'interne du proxy.
+        NP="127.0.0.1,localhost,${CI_REGISTRY:-},${CI_SERVER_HOST:-},.atlas.fabrique.social.gouv.fr,${no_proxy:-}"
+        export no_proxy="$NP" NO_PROXY="$NP"
       fi
       apk add --no-cache curl >/dev/null
-      [ -n "${BUILDKIT_HTTP_PROXY:-}" ] && apk add --no-cache socat >/dev/null
+      [ -n "${BUILDKIT_TUNNEL:-}" ] && apk add --no-cache socat >/dev/null
 
       # 1. buildctl (client buildkit)
       curl -fsSL "https://github.com/moby/buildkit/releases/download/${BUILDCTL_VERSION}/buildkit-${BUILDCTL_VERSION}.linux-amd64.tar.gz" \
@@ -69,10 +71,12 @@
       fi
       echo "buildkitd: $ADDR"
 
-      # 4b. Tunnel TCP via proxy HTTP CONNECT (buildctl ne gère pas le proxy nativement).
-      #     Le SAN du cert daemon couvre *.buildkit.atlas.fabrique... -> --tlsservername OK.
+      # 4b. Connexion buildctl -> buildkitd.
+      #   Par défaut : DIRECT (le runner a un egress direct vers le LB public buildkit).
+      #   Si BUILDKIT_TUNNEL=1 : tunnel TCP via proxy HTTP CONNECT (souvent bloqué hors 443).
+      #   SAN du cert daemon : *.buildkit.atlas.fabrique... -> --tlsservername OK.
       TLS_SRV=""
-      if [ -n "${BUILDKIT_HTTP_PROXY:-}" ]; then
+      if [ -n "${BUILDKIT_TUNNEL:-}" ] && [ -n "${BUILDKIT_HTTP_PROXY:-}" ]; then
         BK="${ADDR#tcp://}"; BKHOST="${BK%%:*}"; BKPORT="${BK##*:}"
         PHOST="${BUILDKIT_HTTP_PROXY%%:*}"; PPORT="${BUILDKIT_HTTP_PROXY##*:}"
         socat TCP-LISTEN:18080,fork,reuseaddr "PROXY:${PHOST}:${BKHOST}:${BKPORT},proxyport=${PPORT}" &

--- a/.gitlab/ci/buildkit.yml
+++ b/.gitlab/ci/buildkit.yml
@@ -1,0 +1,88 @@
+# ============================================================================
+# Template BuildKit mutualisé (SEED) — à extraire vers un repo PIC partagé
+# (ex. socialgouv/.../ci-buildkit) puis inclure via `include: component:`/`project:`.
+#
+# Reproduit l'action SocialGouv actions/buildkit : buildctl → buildkitd DISTANT
+# (sur ovh-prod, maintenu en interne), mTLS, distribution modulo (localité de cache),
+# cache registre. Voir docs/15-build-ci/buildkit-mutualise.md.
+#
+# Variables CI/CD requises (groupe/projet GitLab PIC) :
+#   BUILDKIT_DAEMON_ADDRESS  ex: tcp://buildkit.<...>:1234
+#   BUILDKIT_SVC_COUNT       nombre de réplicas (distribution modulo)
+#   BUILDKIT_CERT_CA / BUILDKIT_CERT / BUILDKIT_CERT_KEY  (mTLS inline, masqués/protégés)
+# Registre : variables natives $CI_REGISTRY*.
+# ============================================================================
+
+.buildkit-build:
+  image: alpine:3.20
+  variables:
+    BUILDKIT_IMAGE: "$CI_REGISTRY_IMAGE/app"   # repo destination (SANS tag)
+    BUILDKIT_TAGS: "sha-$CI_COMMIT_SHA"         # tags séparés par des virgules
+    BUILDKIT_CONTEXT: "."
+    BUILDKIT_DOCKERFILE: "Dockerfile"
+    BUILDKIT_PLATFORMS: "linux/amd64"
+    BUILDKIT_BUILD_ARGS: ""                     # multi-lignes "K=V"
+    BUILDKIT_TARGET: ""
+    BUILDKIT_PUSH: "true"
+    BUILDCTL_VERSION: "v0.22.0"
+  script:
+    - |
+      set -eu
+      apk add --no-cache curl >/dev/null
+
+      # 1. buildctl (client buildkit)
+      curl -fsSL "https://github.com/moby/buildkit/releases/download/${BUILDCTL_VERSION}/buildkit-${BUILDCTL_VERSION}.linux-amd64.tar.gz" \
+        | tar -C /usr/local -xz bin/buildctl
+
+      # 2. login registre GitLab
+      mkdir -p "$HOME/.docker"
+      printf '{"auths":{"%s":{"username":"%s","password":"%s"}}}' \
+        "$CI_REGISTRY" "$CI_REGISTRY_USER" "$CI_REGISTRY_PASSWORD" > "$HOME/.docker/config.json"
+
+      # 3. certs mTLS (inline -> fichiers)
+      CERT_DIR="$(mktemp -d)"
+      printf '%s' "$BUILDKIT_CERT_CA"  > "$CERT_DIR/ca.pem"
+      printf '%s' "$BUILDKIT_CERT"     > "$CERT_DIR/cert.pem"
+      printf '%s' "$BUILDKIT_CERT_KEY" > "$CERT_DIR/key.pem"
+
+      # 4. distribution modulo sur les réplicas (localité de cache)
+      ADDR="$BUILDKIT_DAEMON_ADDRESS"
+      N="${BUILDKIT_SVC_COUNT:-1}"
+      if [ "$N" -gt 0 ]; then
+        H="$(printf '%s' "$BUILDKIT_IMAGE" | md5sum | cut -c1-8)"
+        IDX=$(( 0x$H % N ))
+        PREFIX="${ADDR%%.*}"; PROTO="${PREFIX%%://*}"; SUB="${PREFIX#*//}"
+        ADDR="$(printf '%s' "$ADDR" | sed "s|$PREFIX|$PROTO://$SUB-$IDX.$SUB|")"
+      fi
+      echo "buildkitd: $ADDR"
+
+      # 5. build-args (multi-lignes "K=V") -> "--opt build-arg:K=V ..."
+      OPT_ARGS="$(printf '%s\n' "$BUILDKIT_BUILD_ARGS" | awk 'NF{printf " --opt build-arg:%s", $0}')"
+
+      # noms de sortie = IMAGE:tag pour chaque tag (séparés par virgule)
+      NAMES="$(printf '%s' "$BUILDKIT_TAGS" | tr ',' '\n' | awk -v p="${BUILDKIT_IMAGE}:" 'NF{printf "%s%s%s",(n++?",":""),p,$0}')"
+
+      TGT=""
+      [ -n "$BUILDKIT_TARGET" ] && TGT="--opt target=$BUILDKIT_TARGET"
+
+      # 6. build + push (cache registre import/export)
+      # shellcheck disable=SC2086
+      buildctl --addr "$ADDR" \
+        --tlscacert "$CERT_DIR/ca.pem" --tlscert "$CERT_DIR/cert.pem" --tlskey "$CERT_DIR/key.pem" \
+        build \
+        --frontend dockerfile.v0 \
+        --local context="$BUILDKIT_CONTEXT" \
+        --local dockerfile="$BUILDKIT_CONTEXT" \
+        --opt filename="./$BUILDKIT_DOCKERFILE" \
+        --opt platform="$BUILDKIT_PLATFORMS" \
+        $OPT_ARGS $TGT \
+        --import-cache "type=registry,ref=${BUILDKIT_IMAGE}:cache-${CI_DEFAULT_BRANCH}" \
+        --export-cache "type=registry,mode=max,image-manifest=true,ignore-error=true,ref=${BUILDKIT_IMAGE}:cache-${CI_COMMIT_REF_SLUG}" \
+        --output "type=image,\"name=${NAMES}\",push=${BUILDKIT_PUSH}"
+
+      # 7. dotenv pour le downstream (publish/deploy)
+      echo "BUILT_IMAGE=${BUILDKIT_IMAGE}" > build.env
+      echo "BUILT_TAG=${BUILDKIT_TAGS%%,*}" >> build.env
+  artifacts:
+    reports:
+      dotenv: build.env

--- a/charts/da-manager/Chart.yaml
+++ b/charts/da-manager/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: da-manager
+description: DA Manager (Document d'Architecture form builder) — platform-agnostic application chart
+type: application
+# Chart version is bumped/overwritten by CI at publish time (snapshot 0.0.0-sha.<sha> or release tag).
+version: 0.1.0
+# appVersion = image tag by default (see templates/_helpers.tpl "da-manager.image").
+appVersion: "1.2.0"

--- a/charts/da-manager/templates/NOTES.txt
+++ b/charts/da-manager/templates/NOTES.txt
@@ -1,0 +1,11 @@
+da-manager déployé ({{ include "da-manager.fullname" . }}).
+
+Image    : {{ include "da-manager.image" . }}
+{{- if .Values.ingress.enabled }}
+URL      : https://{{ .Values.ingress.host }}
+{{- end }}
+
+Migrations Drizzle : exécutées automatiquement au démarrage de l'app (instrumentation.ts).
+Secrets attendus (fournis par ExternalSecrets côté gitops) :
+  - {{ .Values.secrets.proconnect }} : PROCONNECT_CLIENT_ID, PROCONNECT_CLIENT_SECRET, AUTH_SECRET
+  - {{ .Values.secrets.database }} : DATABASE_URL

--- a/charts/da-manager/templates/_helpers.tpl
+++ b/charts/da-manager/templates/_helpers.tpl
@@ -1,0 +1,54 @@
+{{- define "da-manager.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "da-manager.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "da-manager.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "da-manager.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "da-manager.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "da-manager.labels" -}}
+helm.sh/chart: {{ include "da-manager.chart" . }}
+{{ include "da-manager.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.global.extraLabels }}
+{{ toYaml . | trim }}
+{{- end }}
+{{- end -}}
+
+{{- define "da-manager.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "da-manager.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Full image reference: <global.imageRegistry>/<image.repository>:<tag|appVersion> */}}
+{{- define "da-manager.image" -}}
+{{- $reg := .Values.global.imageRegistry | trimSuffix "/" -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- if $reg -}}
+{{- printf "%s/%s:%s" $reg .Values.image.repository $tag -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}
+{{- end -}}

--- a/charts/da-manager/templates/configmap.yaml
+++ b/charts/da-manager/templates/configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "da-manager.fullname" . }}
+  labels:
+    {{- include "da-manager.labels" . | nindent 4 }}
+data:
+  {{- $data := .Values.configMap.data | default dict }}
+  {{- if and (not (hasKey $data "AUTH_URL")) .Values.ingress.host }}
+  # AUTH_URL dérivé du host (NextAuth, runtime) — surchargé si fourni explicitement.
+  AUTH_URL: {{ printf "https://%s" .Values.ingress.host | quote }}
+  {{- end }}
+  {{- range $k, $v := $data }}
+  {{ $k }}: {{ $v | quote }}
+  {{- end }}

--- a/charts/da-manager/templates/deployment.yaml
+++ b/charts/da-manager/templates/deployment.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "da-manager.fullname" . }}
+  labels:
+    {{- include "da-manager.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "da-manager.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "da-manager.labels" . | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "da-manager.serviceAccountName" . }}
+      containers:
+        - name: app
+          image: {{ include "da-manager.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.probes.port }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "da-manager.fullname" . }}
+            - secretRef:
+                name: {{ .Values.secrets.proconnect }}
+            - secretRef:
+                name: {{ .Values.secrets.database }}
+          {{- with .Values.env }}
+          env:
+            {{- range $k, $v := . }}
+            - name: {{ $k }}
+              value: {{ $v | quote }}
+            {{- end }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probes.path }}
+              port: {{ .Values.probes.port }}
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probes.path }}
+              port: {{ .Values.probes.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/da-manager/templates/hpa.yaml
+++ b/charts/da-manager/templates/hpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "da-manager.fullname" . }}
+  labels:
+    {{- include "da-manager.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "da-manager.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/charts/da-manager/templates/ingress.yaml
+++ b/charts/da-manager/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "da-manager.fullname" . }}
+  labels:
+    {{- include "da-manager.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ required "ingress.host is required when ingress.enabled" .Values.ingress.host | quote }}
+      {{- with .Values.ingress.tls.secretName }}
+      secretName: {{ . }}
+      {{- end }}
+  {{- end }}
+  rules:
+    - host: {{ required "ingress.host is required when ingress.enabled" .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "da-manager.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}
+{{- end }}

--- a/charts/da-manager/templates/pdb.yaml
+++ b/charts/da-manager/templates/pdb.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "da-manager.fullname" . }}
+  labels:
+    {{- include "da-manager.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "da-manager.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/da-manager/templates/service.yaml
+++ b/charts/da-manager/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "da-manager.fullname" . }}
+  labels:
+    {{- include "da-manager.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "da-manager.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP

--- a/charts/da-manager/templates/serviceaccount.yaml
+++ b/charts/da-manager/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "da-manager.serviceAccountName" . }}
+  labels:
+    {{- include "da-manager.labels" . | nindent 4 }}
+{{- end }}

--- a/charts/da-manager/values.yaml
+++ b/charts/da-manager/values.yaml
@@ -1,0 +1,76 @@
+# Default values — platform-agnostic. Environment-specific values live in the gitops repo.
+# No secrets here: secrets are referenced BY NAME and provided by ExternalSecrets (gitops).
+
+global:
+  # Registry prefix for the image, e.g. "pic-registry.sg.social.gouv.fr/socialgouv/.../da-manager".
+  imageRegistry: ""
+  imagePullSecrets: []        # e.g. [{ name: registry-pull-secret }]
+  extraLabels: {}
+
+image:
+  repository: app             # final ref = <global.imageRegistry>/<repository>:<tag>
+  tag: ""                     # defaults to .Chart.AppVersion when empty
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+replicaCount: 1
+
+service:
+  port: 80
+  targetPort: 3000
+
+ingress:
+  enabled: true
+  className: ""
+  host: ""                    # set per environment (gitops)
+  annotations: {}
+  tls:
+    enabled: true
+    secretName: ""            # empty → ingress controller / cert-manager default
+
+probes:
+  path: /api/healthz
+  port: 3000
+
+resources:
+  requests:
+    cpu: "100m"
+    memory: "512Mi"
+  limits:
+    cpu: "1"
+    memory: "1Gi"
+
+# Non-secret env injected directly (also see configMap.data for env-specific config).
+env:
+  PROCONNECT_ISSUER: "https://fca.integ01.dev-agentconnect.fr/api/v2"
+
+# Rendered into a ConfigMap (name = fullname) and loaded via envFrom.
+# Per-env keys (gitops): ALLOWED_EMAIL_DOMAINS, ENABLE_DEV_LOGIN, AUTH_URL, ...
+configMap:
+  data: {}
+
+# Names of pre-existing Secrets (created by ExternalSecrets in the gitops repo), loaded via envFrom.
+secrets:
+  proconnect: proconnect      # PROCONNECT_CLIENT_ID, PROCONNECT_CLIENT_SECRET, AUTH_SECRET
+  database: pg-app            # DATABASE_URL
+
+serviceAccount:
+  create: true
+  name: ""
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80
+
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+
+podAnnotations: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
## Objectif

Mettre en place la **CD sur la PIC (GitLab)** pour da-manager, en gardant la **CI de code (tests/lint/release) sur GitHub**. Le repo est mirroré sur la PIC (`socialgouv/produits-dnum/tooling/da-manager`) ; ce pipeline GitLab tourne sur le miroir. Déploiement cible : **Atlas v2**, d'abord via un **environnement de review par branche** (à la vao, valeurs seedées depuis le slug de branche).

## Contenu

- **`charts/da-manager/`** — chart Helm plateforme-agnostique (Deployment/Service/Ingress/ConfigMap/ServiceAccount, HPA/PDB optionnels). `AUTH_URL` dérivé du host ; migrations Drizzle exécutées au démarrage de l'app (pas de Job). Secrets référencés par nom (fournis par External Secrets côté gitops). Validé `helm lint` + `kubeconform`.
- **`.gitlab/ci/buildkit.yml`** — template de build **mutualisé** : `buildctl` → **buildkitd distant** (mTLS, distribution modulo, cache registre), reproduisant l'action SocialGouv `actions/buildkit`. Image poussée sur le registre PIC.
- **`.gitlab-ci.yml`** — `build` → `publish-chart` (OCI) → `deploy-review`/`stop-review` : crée/maj un env de review par branche dans le repo gitops `da-manager-gitops`.

## Prérequis (variables CI/CD PIC)

- `BUILDKIT_DAEMON_ADDRESS`, `BUILDKIT_SVC_COUNT`, `BUILDKIT_CERT_CA`, `BUILDKIT_CERT`, `BUILDKIT_CERT_KEY`
- `GITOPS_TOKEN` (write `da-manager-gitops`), `REVIEW_DOMAIN`

## Suite

Onboarding Atlas v2 (Workspace/Environment + Vault/External Secrets + Postgres OVH) et activation du miroir GitHub→PIC. La CD Fabrique actuelle (`.kontinuous/`, workflows `preproduction/production/review/deactivate`) sera retirée après validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
