### PR TITLE
ci: migrate image builds from buildkit-service to buildkit-operator

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,8 +37,6 @@ jobs:
           fetch-depth: 0 # Shallow clones should be disabled for better SonarCloud analysis
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: latest
 
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/.github/workflows/claude-issue.yml
+++ b/.github/workflows/claude-issue.yml
@@ -26,8 +26,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: latest
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/claude-pr.yml
+++ b/.github/workflows/claude-pr.yml
@@ -33,8 +33,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: latest
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/preproduction.yaml
+++ b/.github/workflows/preproduction.yaml
@@ -12,6 +12,9 @@ concurrency:
 jobs:
   build-app:
     environment: build-preproduction
+    permissions:
+      contents: read
+      id-token: write # OIDC identity for buildkit-operator /route auth
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
     runs-on: ubuntu-latest
@@ -28,24 +31,29 @@ jobs:
             type=sha,prefix=preprod-,format=long,priority=890
             type=sha,prefix=sha-,format=long,priority=880
 
-      - name: 📦 Build and push Docker image
-        uses: socialgouv/workflows/actions/buildkit@v1
+      - name: 🔑 Login to registry
+        uses: docker/login-action@v4
         with:
+          registry: ${{ vars.REGISTRY_URL }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: 📦 Build and push Docker image
+        uses: socialgouv/buildkit-operator@v1
+        with:
+          buildd-url: ${{ vars.BUILDKIT_OPERATOR_BUILDD_URL }}
+          gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST }}
+          ca: ${{ secrets.BUILDKIT_OPERATOR_CA }}
+          cert: ${{ secrets.BUILDKIT_OPERATOR_CERT }}
+          key: ${{ secrets.BUILDKIT_OPERATOR_KEY }}
           context: "."
-          dockerfile: "Dockerfile"
+          file: "Dockerfile"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             AUTH_URL=https://da-manager-preprod.ovh.fabrique.social.gouv.fr
             NEXT_PUBLIC_ENABLE_DEV_LOGIN=true
-          registry: "${{ vars.REGISTRY_URL }}"
-          registry-username: "${{ secrets.REGISTRY_USERNAME }}"
-          registry-password: "${{ secrets.REGISTRY_PASSWORD }}"
-          buildkit-cert-ca: "${{ secrets.BUILDKIT_CERT_CA }}"
-          buildkit-cert: "${{ secrets.BUILDKIT_CERT }}"
-          buildkit-cert-key: "${{ secrets.BUILDKIT_CERT_KEY }}"
-          buildkit-svc-count: ${{ vars.BUILDKIT_SVC_COUNT }}
-          buildkit-daemon-address: ${{ vars.BUILDKIT_DAEMON_ADDRESS }}
+          push: true
 
   kontinuous:
     needs: [build-app]

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -12,6 +12,9 @@ concurrency:
 jobs:
   build-app:
     environment: build-production
+    permissions:
+      contents: read
+      id-token: write # OIDC identity for buildkit-operator /route auth
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
     runs-on: ubuntu-latest
@@ -29,23 +32,28 @@ jobs:
             type=sha,prefix=sha-,format=long,priority=880
             type=raw,value=latest,priority=600
 
-      - name: 📦 Build and push Docker image
-        uses: socialgouv/workflows/actions/buildkit@v1
+      - name: 🔑 Login to registry
+        uses: docker/login-action@v4
         with:
+          registry: ${{ vars.REGISTRY_URL }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: 📦 Build and push Docker image
+        uses: socialgouv/buildkit-operator@v1
+        with:
+          buildd-url: ${{ vars.BUILDKIT_OPERATOR_BUILDD_URL }}
+          gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST }}
+          ca: ${{ secrets.BUILDKIT_OPERATOR_CA }}
+          cert: ${{ secrets.BUILDKIT_OPERATOR_CERT }}
+          key: ${{ secrets.BUILDKIT_OPERATOR_KEY }}
           context: "."
-          dockerfile: "Dockerfile"
+          file: "Dockerfile"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             AUTH_URL=https://da-manager.fabrique.social.gouv.fr
-          registry: "${{ vars.REGISTRY_URL }}"
-          registry-username: "${{ secrets.REGISTRY_USERNAME }}"
-          registry-password: "${{ secrets.REGISTRY_PASSWORD }}"
-          buildkit-cert-ca: "${{ secrets.BUILDKIT_CERT_CA }}"
-          buildkit-cert: "${{ secrets.BUILDKIT_CERT }}"
-          buildkit-cert-key: "${{ secrets.BUILDKIT_CERT_KEY }}"
-          buildkit-svc-count: ${{ vars.BUILDKIT_SVC_COUNT }}
-          buildkit-daemon-address: ${{ vars.BUILDKIT_DAEMON_ADDRESS }}
+          push: true
 
   kontinuous:
     needs: [build-app]

--- a/.github/workflows/review.yaml
+++ b/.github/workflows/review.yaml
@@ -16,6 +16,9 @@ concurrency:
 jobs:
   build-app:
     environment: build-review-auto
+    permissions:
+      contents: read
+      id-token: write # OIDC identity for buildkit-operator /route auth
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
     runs-on: ubuntu-latest
@@ -43,24 +46,29 @@ jobs:
         id: env
         uses: socialgouv/kontinuous/.github/actions/env@v1
 
-      - name: 📦 Build and push Docker image
-        uses: socialgouv/workflows/actions/buildkit@v1
+      - name: 🔑 Login to registry
+        uses: docker/login-action@v4
         with:
+          registry: ${{ vars.REGISTRY_URL }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: 📦 Build and push Docker image
+        uses: socialgouv/buildkit-operator@v1
+        with:
+          buildd-url: ${{ vars.BUILDKIT_OPERATOR_BUILDD_URL }}
+          gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST }}
+          ca: ${{ secrets.BUILDKIT_OPERATOR_CA }}
+          cert: ${{ secrets.BUILDKIT_OPERATOR_CERT }}
+          key: ${{ secrets.BUILDKIT_OPERATOR_KEY }}
           context: "."
-          dockerfile: "Dockerfile"
+          file: "Dockerfile"
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             AUTH_URL=https://${{ steps.env.outputs.subdomain }}.ovh.fabrique.social.gouv.fr
             NEXT_PUBLIC_ENABLE_DEV_LOGIN=true
-          registry: "${{ vars.REGISTRY_URL }}"
-          registry-username: "${{ secrets.REGISTRY_USERNAME }}"
-          registry-password: "${{ secrets.REGISTRY_PASSWORD }}"
-          buildkit-cert-ca: "${{ secrets.BUILDKIT_CERT_CA }}"
-          buildkit-cert: "${{ secrets.BUILDKIT_CERT }}"
-          buildkit-cert-key: "${{ secrets.BUILDKIT_CERT_KEY }}"
-          buildkit-svc-count: ${{ vars.BUILDKIT_SVC_COUNT }}
-          buildkit-daemon-address: ${{ vars.BUILDKIT_DAEMON_ADDRESS }}
+          push: true
 
   kontinuous:
     needs: [build-app]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # Stage 1: Dependencies
 FROM node:22-alpine AS deps
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@10.34.3 --activate
 
 WORKDIR /app
 
@@ -14,7 +14,7 @@ RUN pnpm install --frozen-lockfile
 
 # Stage 2: Builder
 FROM node:22-alpine AS builder
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@10.34.3 --activate
 
 WORKDIR /app
 

--- a/package.json
+++ b/package.json
@@ -45,5 +45,6 @@
     "prettier": "^3.8.1",
     "typescript": "^5",
     "vitest": "^4.0.18"
-  }
+  },
+  "packageManager": "pnpm@10.34.3"
 }


### PR DESCRIPTION
## Quoi

Migre les builds d'images CI du service legacy **buildkit-service** (flotte de daemons partagés, `buildctl` sur le runner via `socialgouv/workflows/actions/buildkit@v1`) vers **[buildkit-operator](https://github.com/SocialGouv/buildkit-operator)** (`socialgouv/buildkit-operator@v1`) : chaque build est routé vers le buildkitd chaud **dédié au repo** (cache par projet). Même migration que SocialGouv/revu#278.

## Mapping (workflows review / preproduction / production)

- `socialgouv/workflows/actions/buildkit@v1` → `socialgouv/buildkit-operator@v1` (`dockerfile:` → `file:`, `push: true` explicite, `build-args` inchangés).
- Auth `/route` : **GitHub OIDC** (`permissions.id-token: write` sur le job) — identité du repo vérifiée côté serveur, aucun token partagé.
- Secrets/vars **org-level** déjà en place (`BUILDKIT_OPERATOR_CA/CERT/KEY`, `BUILDKIT_OPERATOR_BUILDD_URL`, `BUILDKIT_OPERATOR_GATEWAY_HOST`) → zéro setup côté repo.
- Login registry : `docker/login-action@v4` (l'auth est forwardée au daemon via la session buildx).
- Supprimés (sans objet) : `buildkit-daemon-address`, `buildkit-svc-count`, `buildkit-cert-*`.

## Fix embarqué : pin pnpm (build cassé indépendamment de la migration)

Le Dockerfile faisait `corepack prepare pnpm@latest` ; « latest » est passé à pnpm 11, qui transforme les build scripts non approuvés en erreur fatale (`ERR_PNPM_IGNORED_BUILDS`) — tout build échouait, y compris sur le service legacy. Pin sur `pnpm@10.34.3` (dernière 10.x) = sémantique exacte des derniers builds verts (27 mai).

## Validation ([run review 28606031697](https://github.com/SocialGouv/da-manager/actions/runs/28606031697) sur cette branche)

- ✅ `build-app` : OIDC accepté, routé `SocialGouv/da-manager → buildkitd-p969f56eaabec6ae7.bkod.fabrique.social.gouv.fr:443`, S3 cold cache ON, image poussée (digest `sha256:64224c84…`).
- ✅ `Deploy Review on Kubernetes` : vert — **e2e complet build + deploy**.

## Rollback

Revert de cette PR — buildkit-service reste en service pendant toute la migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)